### PR TITLE
Be strict about cli options to avoid silent mistakes

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -180,6 +180,7 @@ function argsParser () {
           type: 'boolean'
         })
     })
+    .strict()
     .help()
 }
 


### PR DESCRIPTION
It happened a lot with --require-template option