### PR TITLE
Resolves #17, Resolves #18, Support --destination-dir --out-file

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,15 +1,19 @@
 /* global Opal */
 const util = require('util')
 const fs = require('fs')
+const fsExtra = require('fs-extra')
 const path = require('path')
-const writeFile = util.promisify(fs.writeFile)
+const removeFile = util.promisify(fs.unlink)
+const existsFile = util.promisify(fs.stat)
+const readFile = util.promisify(fs.readFile)
+const mkdirs = util.promisify(fsExtra.mkdirs)
 const puppeteer = require('puppeteer')
 
 function registerTemplateConverter (processor, templates) {
   class TemplateConverter {
     constructor () {
       this.baseConverter = processor.Html5Converter.create()
-      this.templates = templates;
+      this.templates = templates
     }
 
     convert (node, transform, opts) {
@@ -25,43 +29,56 @@ function registerTemplateConverter (processor, templates) {
 }
 
 async function convert (processor, inputFile, options, timings) {
-  let html;
-  let doc;
+  const tempFile = getTemporaryHtmlFile(inputFile, options)
+  let workingDir
+  if (options.to_dir) {
+    await mkdirs(options.to_dir)
+    workingDir = options.to_dir
+  } else {
+    workingDir = path.dirname(inputFile)
+  }
+  const inputFilenameWithoutExt = path.basename(inputFile, path.extname(inputFile))
+  let outputFile = path.join(workingDir, inputFilenameWithoutExt + '.pdf')
+  let outputToStdout = false
+  if (options.to_file) {
+    if (options.to_file !== Opal.gvars.stdout) {
+      await mkdirs(path.dirname(options.to_file))
+      if (options.to_dir) {
+        outputFile = path.join(options.to_dir, options.to_file)
+      } else {
+        outputFile = options.to_file
+      }
+    } else {
+      outputToStdout = true
+    }
+  }
+  options.to_file = tempFile
+  let doc
   if (timings) {
     const timings = processor.Timings.$new()
     const instanceOptions = Object.assign({}, options, { timings: timings })
-    doc = processor.loadFile(inputFile, instanceOptions)
-    html = doc.convert(instanceOptions)
+    doc = processor.convertFile(inputFile, instanceOptions)
     timings.$print_report(Opal.gvars.stderr, inputFile)
   } else {
-    doc = processor.loadFile(inputFile, options)
-    html = doc.convert(options)
-  }
-  const workingDir = path.dirname(inputFile)
-  const inputFilenameWithoutExt = path.basename(inputFile, path.extname(inputFile))
-  const outputFile = path.join(workingDir, inputFilenameWithoutExt + '.pdf')
-  let tempFile;
-  if (path.isAbsolute(workingDir)) {
-    tempFile = path.join(workingDir, inputFilenameWithoutExt + '_temp.html')
-  } else {
-    tempFile = path.normalize(path.join(process.cwd(), workingDir, inputFilenameWithoutExt + '_temp.html'))
+    doc = processor.convertFile(inputFile, options)
   }
   const puppeteerConfig = {
     headless: true,
     args: ['--no-sandbox', '--allow-file-access-from-files']
   }
-  const browser = await puppeteer.launch(puppeteerConfig);
+  const browser = await puppeteer.launch(puppeteerConfig)
   try {
     const page = await browser.newPage()
     page
       .on('pageerror', err => console.log('Page error: ' + err.toString()))
       .on('error', err => console.log('Error: ' + err.toString()))
-    await writeFile(tempFile, html)
     await page.goto('file://' + tempFile, { waitUntil: 'networkidle2' })
     const pdfOptions = {
-      path: outputFile,
       printBackground: true,
       preferCSSPageSize: true,
+    }
+    if (!outputToStdout) {
+     pdfOptions.path = outputFile
     }
     let pdfWidth = doc.getAttributes()['pdf-width']
     if (pdfWidth) {
@@ -75,7 +92,10 @@ async function convert (processor, inputFile, options, timings) {
     if (format) {
       pdfOptions.format = format // Paper format. If set, takes priority over width or height options. Defaults to 'Letter'.
     }
-    return await page.pdf(pdfOptions)
+    const pdf = await page.pdf(pdfOptions)
+    if (outputToStdout) {
+      console.log(pdf.toString())
+    }
   } finally {
     try {
       await browser.close()
@@ -83,6 +103,42 @@ async function convert (processor, inputFile, options, timings) {
       console.log('Unable to close the browser - Error: ' + err.toString())
     }
   }
+}
+
+async function safelyReadFile (file) {
+  try {
+    if (await existsFile(file)) {
+      return await readFile(file, 'utf-8')
+    }
+  } catch (err) {
+    console.log(`Unable to read the file ${file} - Error: ${err.toString()}`)
+  }
+}
+
+async function safelyRemoveFile (file) {
+  try {
+    if (await existsFile(file)) {
+      await removeFile(file)
+    }
+  } catch (err) {
+    console.log(`Unable to remove the file ${file} - Error: ${err.toString()}`)
+  }
+}
+
+function getTemporaryHtmlFile (inputFile) {
+  const workingDir = path.dirname(inputFile)
+  const inputFilenameWithoutExt = path.basename(inputFile, path.extname(inputFile))
+  let tempFile
+  if (path.isAbsolute(workingDir)) {
+    tempFile = path.join(workingDir, `${inputFilenameWithoutExt}.html`)
+  } else {
+    tempFile = path.normalize(path.join(process.cwd(), workingDir, `${inputFilenameWithoutExt}.html`))
+  }
+  return tempFile
+}
+
+function getCoreVersion () {
+  return asciidoctor.getCoreVersion()
 }
 
 module.exports = {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -3,9 +3,6 @@ const util = require('util')
 const fs = require('fs')
 const fsExtra = require('fs-extra')
 const path = require('path')
-const removeFile = util.promisify(fs.unlink)
-const existsFile = util.promisify(fs.stat)
-const readFile = util.promisify(fs.readFile)
 const mkdirs = util.promisify(fsExtra.mkdirs)
 const puppeteer = require('puppeteer')
 
@@ -102,26 +99,6 @@ async function convert (processor, inputFile, options, timings) {
     } catch (err) {
       console.log('Unable to close the browser - Error: ' + err.toString())
     }
-  }
-}
-
-async function safelyReadFile (file) {
-  try {
-    if (await existsFile(file)) {
-      return await readFile(file, 'utf-8')
-    }
-  } catch (err) {
-    console.log(`Unable to read the file ${file} - Error: ${err.toString()}`)
-  }
-}
-
-async function safelyRemoveFile (file) {
-  try {
-    if (await existsFile(file)) {
-      await removeFile(file)
-    }
-  } catch (err) {
-    console.log(`Unable to remove the file ${file} - Error: ${err.toString()}`)
   }
 }
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -114,10 +114,6 @@ function getTemporaryHtmlFile (inputFile) {
   return tempFile
 }
 
-function getCoreVersion () {
-  return asciidoctor.getCoreVersion()
-}
-
 module.exports = {
   convert: convert,
   registerTemplateConverter: registerTemplateConverter

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,6 +709,16 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1399,6 +1409,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -2215,6 +2233,11 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@asciidoctor/cli": "3.0.0",
     "chokidar": "2.0.4",
+    "fs-extra": "7.0.1",
     "pagedjs": "^0.1.34",
     "puppeteer": "1.15.0",
     "yargs": "13.2.2"


### PR DESCRIPTION
ping @matklad :wink: 

So the following is supported:

```
-o foo/bar/baz/book.pdf
```
Will create `foo`, `bar` and `baz` directories (if they don't exist).

```
-o -
```

Will output the result (pdf content) to the console

```
-D foo/bar/baz -o book.pdf
```
Will create `foo`, `bar` and `baz` directories (if they don't exist).

```
-o book.pdf
```
Will create a file named `book.pdf`


Please note that for now we do not remove the temporary HTML file (to ease development/debugging).
Also the temporary HTML file is always created next to the input file. So you don't have to update the relative paths when you want to output the PDF file somewhere else.
