### PR TITLE
Add outline to pdf documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 *_temp.html
+/test/output/*.pdf
+/test/fixtures/*.html

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -98,13 +98,13 @@ async function convert (processor, inputFile, options, timings, preview) {
       }
 
       let pdf = await page.pdf(pdfOptions)
-      if (doc.getAttribute('toc') !== undefined) {
-        // Outline is not yet implemented in Chromium, so we add it manually here
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=840455
-        pdf = await addOutline(pdf, doc)
-      }
+      // Outline is not yet implemented in Chromium, so we add it manually here.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=840455
+      pdf = await addOutline(pdf, doc)
       if (outputToStdout) {
         console.log(pdf.toString())
+      } else {
+        fsExtra.writeFileSync(outputFile, pdf)
       }
     }
   } finally {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -4,6 +4,7 @@ const fsExtra = require('fs-extra')
 const path = require('path')
 const mkdirs = util.promisify(fsExtra.mkdirs)
 const puppeteer = require('puppeteer')
+const { addOutline } = require('./outline.js')
 
 function registerTemplateConverter (processor, templates) {
   class TemplateConverter {
@@ -83,9 +84,6 @@ async function convert (processor, inputFile, options, timings, preview) {
         printBackground: true,
         preferCSSPageSize: true
       }
-      if (!outputToStdout) {
-        pdfOptions.path = outputFile
-      }
       const pdfWidth = doc.getAttributes()['pdf-width']
       if (pdfWidth) {
         pdfOptions.width = pdfWidth
@@ -98,7 +96,13 @@ async function convert (processor, inputFile, options, timings, preview) {
       if (format) {
         pdfOptions.format = format // Paper format. If set, takes priority over width or height options. Defaults to 'Letter'.
       }
-      const pdf = await page.pdf(pdfOptions)
+
+      let pdf = await page.pdf(pdfOptions)
+      if (doc.getAttribute('toc') !== undefined) {
+        // Outline is not yet implemented in Chromium, so we add it manually here
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=840455
+        pdf = await addOutline(pdf, doc)
+      }
       if (outputToStdout) {
         console.log(pdf.toString())
       }

--- a/lib/document/templates.js
+++ b/lib/document/templates.js
@@ -14,12 +14,12 @@ const faNoteIcon = faIcon(faInfoCircle)
 const faWarningIcon = faIcon(faExclamationTriangle)
 const faCautionIcon = faLayer((push) => {
   push(faIcon(faCircle))
-  push(faIcon(faHandPaper, {transform: { size: 10, x: -0.5 }}))
+  push(faIcon(faHandPaper, { transform: { size: 10, x: -0.5 } }))
 
 })
 const faTipIcon = faLayer((push) => {
   push(faIcon(faCircle))
-  push(faIcon(faLightbulb, {transform: { size: 10 }}))
+  push(faIcon(faLightbulb, { transform: { size: 10 } }))
 })
 
 const repeatTableHeadersContent = fs.readFileSync(`${__dirname}/repeating-table-headers.js`, 'utf8')
@@ -123,8 +123,18 @@ const titlePage = (node) => {
   return ''
 }
 
+/**
+ * Generate an (hidden) outline otherwise Chrome won't generate "Dests" fields and we won't be able to generate a PDF outline.
+ */
+const outline = (node, baseConverter) => {
+  if (baseConverter) {
+    return `<div style="display: none;">${baseConverter['$convert_outline'](node)}</div>`
+  }
+  return ''
+}
+
 module.exports = {
-  document: (node) => {
+  document: (node, baseConverter) => {
     const cdnBaseUrl = `${assetUriScheme(node)}//cdnjs.cloudflare.com/ajax/libs`
     const linkcss = node.isAttribute('linkcss')
     const contentHTML = `<div id="content" class="content">
@@ -152,6 +162,7 @@ ${syntaxHighlighterHead(node, syntaxHighlighter, { linkcss: linkcss })}
 </head>
 <body class="article">
 ${titlePage(node)}
+${outline(node, baseConverter)}
 ${contentHTML}
 ${footnotes(node)}
 ${syntaxHighlighterFooter(node, syntaxHighlighter, { cdn_base_url: cdnBaseUrl, linkcss: linkcss, self_closing_tag_slash: '/' })}

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -1,0 +1,102 @@
+const { PDFDict, PDFDocument, PDFName, PDFNumber, PDFString } = require('pdf-lib')
+
+function getOutline (node, depth) {
+  if (depth === 0) {
+    return []
+  }
+
+  return node.getSections().map(section => ({
+    title: section.getTitle(),
+    destination: section.getId(),
+    children: getOutline(section, depth - 1)
+  }))
+}
+
+function setRefsForOutlineItems (layer, context, parentRef) {
+  for (const item of layer) {
+    item.ref = context.nextRef()
+    item.parentRef = parentRef
+    setRefsForOutlineItems(item.children, context, item.ref)
+  }
+}
+
+function countChildrenOfOutline (layer) {
+  let count = 0
+  for (const item of layer) {
+    ++count
+    count += countChildrenOfOutline(item.children)
+  }
+  return count
+}
+
+function buildPdfObjectsForOutline (layer, context) {
+  for (const [i, item] of layer.entries()) {
+    const prev = layer[i - 1]
+    const next = layer[i + 1]
+
+    const pdfObject = new Map([
+      [PDFName.of('Title'), PDFString.of(item.title)],
+      [PDFName.of('Dest'), PDFName.of(item.destination)],
+      [PDFName.of('Parent'), item.parentRef]
+    ])
+    if (prev) {
+      pdfObject.set(PDFName.of('Prev'), prev.ref)
+    }
+    if (next) {
+      pdfObject.set(PDFName.of('Next'), next.ref)
+    }
+    if (item.children.length > 0) {
+      pdfObject.set(PDFName.of('First'), item.children[0].ref)
+      pdfObject.set(PDFName.of('Last'), item.children[item.children.length - 1].ref)
+      pdfObject.set(PDFName.of('Count'), PDFNumber.of(countChildrenOfOutline(item.children)))
+    }
+
+    context.assign(item.ref, PDFDict.fromMapWithContext(pdfObject, context))
+
+    buildPdfObjectsForOutline(item.children, context)
+  }
+}
+
+function generateWarningsAboutMissingDestinations (layer, pdfDoc) {
+  const dests = pdfDoc.context.lookup(pdfDoc.catalog.get(PDFName.of('Dests')))
+  const validDestinationTargets = dests.entries().map(([key, _]) => key.value())
+
+  for (const item of layer) {
+    if (!validDestinationTargets.includes('/' + item.destination)) {
+      console.warn(`Unable to find destination ${item.destination} ` +
+      'while generating PDF outline! This likely happened because ' +
+      'an anchor link contained an umlaut ' +
+      '(https://bugs.chromium.org/p/chromium/issues/detail?id=985254).')
+    }
+    generateWarningsAboutMissingDestinations(item.children, pdfDoc)
+  }
+}
+
+async function addOutline (pdf, doc) {
+  const depth = doc.getAttribute('toclevels') || 2
+  const pdfDoc = await PDFDocument.load(pdf)
+  const context = pdfDoc.context
+  const outlineRef = context.nextRef()
+
+  const outline = getOutline(doc, depth)
+  if (outline.length === 0) {
+    return pdf
+  }
+  generateWarningsAboutMissingDestinations(outline, pdfDoc)
+  setRefsForOutlineItems(outline, context, outlineRef)
+  buildPdfObjectsForOutline(outline, context)
+
+  const outlineObject = PDFDict.fromMapWithContext(new Map([
+    [PDFName.of('First'), outline[0].ref],
+    [PDFName.of('Last'), outline[outline.length - 1].ref],
+    [PDFName.of('Count'), PDFNumber.of(countChildrenOfOutline(outline))]
+  ]), context)
+  context.assign(outlineRef, outlineObject)
+
+  pdfDoc.catalog.set(PDFName.of('Outlines'), outlineRef)
+  return pdfDoc.save()
+}
+
+module.exports = {
+  addOutline: addOutline
+}

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -60,13 +60,12 @@ function buildPdfObjectsForOutline (layer, context) {
 function generateWarningsAboutMissingDestinations (layer, pdfDoc) {
   const dests = pdfDoc.context.lookup(pdfDoc.catalog.get(PDFName.of('Dests')))
   const validDestinationTargets = dests.entries().map(([key, _]) => key.value())
-
   for (const item of layer) {
     if (!validDestinationTargets.includes('/' + item.destination)) {
       console.warn(`Unable to find destination ${item.destination} ` +
-      'while generating PDF outline! This likely happened because ' +
-      'an anchor link contained an umlaut ' +
-      '(https://bugs.chromium.org/p/chromium/issues/detail?id=985254).')
+        'while generating PDF outline! This likely happened because ' +
+        'an anchor link contained an umlaut ' +
+        '(https://bugs.chromium.org/p/chromium/issues/detail?id=985254).')
     }
     generateWarningsAboutMissingDestinations(item.children, pdfDoc)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,7 +1596,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1614,11 +1615,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1631,15 +1634,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1742,7 +1748,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1752,6 +1759,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1764,17 +1772,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1791,6 +1802,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1863,7 +1875,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1873,6 +1886,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1948,7 +1962,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1978,6 +1993,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1995,6 +2011,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2033,11 +2050,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,15 @@
         "@fortawesome/fontawesome-common-types": "^0.2.25"
       }
     },
+    "@pdf-lib/standard-fonts": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-0.0.4.tgz",
+      "integrity": "sha512-2pg8hXnChVAF6aSFraXtwB0cx/AgE15FvuLJbdPJSq9LYp1xMp0lapH4+t1HsdD9cA05rnWYLqlEBwS4YK1jLg==",
+      "requires": {
+        "base64-arraybuffer": "^0.1.5",
+        "pako": "^1.0.6"
+      }
+    },
     "@types/node": {
       "version": "12.7.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz",
@@ -325,6 +334,11 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
     },
     "binary-extensions": {
       "version": "1.12.0",
@@ -1582,8 +1596,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1601,13 +1614,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1620,18 +1631,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1734,8 +1742,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1745,7 +1752,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1758,20 +1764,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1788,7 +1791,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1861,8 +1863,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1872,7 +1873,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1948,8 +1948,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1979,7 +1978,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1997,7 +1995,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2036,13 +2033,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3126,6 +3121,11 @@
         "lodash": "^4.17.11"
       }
     },
+    "pako": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3198,6 +3198,17 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "pdf-lib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.2.1.tgz",
+      "integrity": "sha512-emphLPyAtov+ylhJkXQ/xx/Hbsz6QxzHOdqzcMyMz7aGPe3aHcD5HWB0ly8A3TZy8HqAiMrTswXgQ6hAsq8vQQ==",
+      "requires": {
+        "@pdf-lib/standard-fonts": "^0.0.4",
+        "pako": "^1.0.10",
+        "png-ts": "^0.0.3",
+        "tslib": "^1.10.0"
+      }
     },
     "pend": {
       "version": "1.2.0",
@@ -3320,6 +3331,14 @@
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         }
+      }
+    },
+    "png-ts": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/png-ts/-/png-ts-0.0.3.tgz",
+      "integrity": "sha512-Qwn3yMfbrbaN86QjrDAqD1UVJc4AV4hvBCx5Dv9libLd6D20xKtgOFs/UcvD0nnjxWlgS12kEVWCDFd9ZtwB+g==",
+      "requires": {
+        "pako": "^1.0.6"
       }
     },
     "posix-character-classes": {
@@ -4053,8 +4072,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.11.2",
     "chokidar": "2.0.4",
-    "fs-extra": "7.0.1",
-    "pagedjs": "0.1.34",
-    "puppeteer": "2.0.0",
-    "mathjax": "^2.7.6",
     "file-url": "3.0.0",
+    "fs-extra": "7.0.1",
+    "mathjax": "^2.7.6",
+    "pagedjs": "0.1.34",
+    "pdf-lib": "^1.2.1",
+    "puppeteer": "2.0.0",
     "yargs": "13.2.2"
   },
   "devDependencies": {

--- a/test/fixtures/sections.adoc
+++ b/test/fixtures/sections.adoc
@@ -1,0 +1,49 @@
+= Title
+
+<<<
+
+== Section 1
+
+<<<
+
+=== Section 1.1
+
+<<<
+
+==== Section 1.1.1
+
+<<<
+
+===== Section 1.1.1.1
+
+<<<
+
+== Section 2
+
+<<<
+
+=== Section 2.1
+
+<<<
+
+=== Section 2.2
+
+<<<
+
+== Section 3
+
+<<<
+
+=== Section 3.1
+
+<<<
+
+==== Section 3.1.1
+
+<<<
+
+== Section 4
+
+<<<
+
+=== Section 4.1

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -1,0 +1,67 @@
+/* global it, describe */
+const fs = require('fs')
+const { PDFDocument, PDFName, PDFDict } = require('pdf-lib')
+const chai = require('chai')
+const expect = chai.expect
+const dirtyChai = require('dirty-chai')
+chai.use(dirtyChai)
+
+const asciidoctor = require('@asciidoctor/core')()
+const converter = require('../lib/converter.js')
+const templates = require('../lib/document/templates.js')
+converter.registerTemplateConverter(asciidoctor, templates)
+
+describe('PDF converter', () => {
+  const getOutlineRefs = (pdfDoc) => {
+    const values = pdfDoc.context.lookup(pdfDoc.catalog.get(PDFName.of('Outlines'))).context.indirectObjects.values()
+    const dicts = []
+    for (const v of values) {
+      if (v instanceof PDFDict) {
+        dicts.push(v.dict)
+      }
+    }
+    return dicts.filter((d) => Array.from(d.keys()).includes(PDFName.of('Dest')))
+  }
+
+  const convert = async (inputFile, outputFile, options) => {
+    const opts = options || {}
+    opts.to_file = outputFile
+    await converter.convert(asciidoctor, inputFile, opts, false)
+    return PDFDocument.load(fs.readFileSync(outputFile))
+  }
+
+  it('should generate a PDF outline even if the TOC is absent from the output', async function () {
+    this.timeout(10000)
+    const options = { attributes: { toc: 'macro' } }
+    const pdfDoc = await convert(`${__dirname}/fixtures/sections.adoc`, `${__dirname}/output/sections-toc-absent.pdf`, options)
+    const refs = getOutlineRefs(pdfDoc)
+    expect(refs.length).to.equal(9)
+    expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+  })
+
+  it('should generate a PDF outline even if the TOC is not enabled', async function () {
+    this.timeout(10000)
+    const pdfDoc = await convert(`${__dirname}/fixtures/sections.adoc`, `${__dirname}/output/sections-toc-disabled.pdf`)
+    const refs = getOutlineRefs(pdfDoc)
+    expect(refs.length).to.equal(9)
+    expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+  })
+
+  it('should honor toclevels 1 when generating a PDF outline', async function () {
+    this.timeout(10000)
+    const options = { attributes: { toclevels: 1 } }
+    const pdfDoc = await convert(`${__dirname}/fixtures/sections.adoc`, `${__dirname}/output/sections-toclevels-1.pdf`, options)
+    const refs = getOutlineRefs(pdfDoc)
+    expect(refs.length).to.equal(4)
+    expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+  })
+
+  it('should honor toclevels 3 when generating a PDF outline', async function () {
+    this.timeout(10000)
+    const options = { attributes: { toclevels: 3 } }
+    const pdfDoc = await convert(`${__dirname}/fixtures/sections.adoc`, `${__dirname}/output/sections-toclevels-1.pdf`, options)
+    const refs = getOutlineRefs(pdfDoc)
+    expect(refs.length).to.equal(11)
+    expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+  })
+})


### PR DESCRIPTION
Ideally this would be handled by Chrome during printing. However,
https://bugs.chromium.org/p/chromium/issues/detail?id=840455 is not
implemented yet (and cannot rely on metadata extracted from the asciidoc
format directly).

Therefore this implements it by introducing some kind of post-processing
using `pdf-lib`. If the `:toc:` property is set, the `.adoc` file is
scanned for sections (respecting the `:toclevels:` attribute) and an
outline is generated.

This only works if a ToC is also generated within the document (or
better: links exist to each section), because otherwise Chrome would not
generate the necessary `Dests` fields within the PDF.

Unfortunately, Chrome also has some bugs regarding Umlaute in anchors,
leading to omission of the relevant `Dests` fields. Therefore a warning
is printed if a anchor cannot be located in the `Dests` field of the PDF
catalog.

Based upon
https://gitlab.pagedmedia.org/tools/pagedjs-cli/commit/df0d10bd1bb12d1e2077323e1fb5eec75da35a1e
which itself is based on @Dopding's comment at:
https://github.com/Hopding/pdf-lib/issues/127#issuecomment-502450179

Depends on #76 because it touches the same lines