### PR TITLE
Capture console output and display a helpful message when the page throws an exception

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -25,6 +25,20 @@ function registerTemplateConverter (processor, templates) {
   processor.ConverterFactory.register(new TemplateConverter(), ['html5'])
 }
 
+const consoleLog = (msg) => {
+  const type = msg.type()
+  if (type === 'error') {
+    const location = msg.location()
+    let text = msg.text()
+    if (location && location.url) {
+      text = `${text} at ${location.url}:${location.lineNumber || 1}`
+    }
+    console.error(text)
+  } else {
+    console.log(msg.text())
+  }
+}
+
 async function convert (processor, inputFile, options, timings, preview) {
   const tempFile = getTemporaryHtmlFile(inputFile, options)
   let workingDir
@@ -76,9 +90,19 @@ async function convert (processor, inputFile, options, timings, preview) {
       page = await browser.newPage()
     }
     page
-      .on('pageerror', err => console.log('Page error: ' + err.toString()))
-      .on('error', err => console.log('Error: ' + err.toString()))
-    await page.goto('file://' + tempFile, { waitUntil: 'networkidle2' })
+      .on('pageerror', err => {
+        console.error('> An uncaught exception happened within the HTML page: ' + err.toString())
+        console.log('')
+        console.log('TIP: You can add the --preview option to open the HTML page in a non-headless browser and debug it using the Developer Tools.')
+      })
+      .on('error', err => {
+        console.error('Page crashed: ' + err.toString())
+      })
+    if (!preview) {
+      // capture console output
+      page.on('console', msg => consoleLog(msg))
+    }
+    await page.goto(`file://${tempFile}`, { waitUntil: 'networkidle2' })
     if (!preview) {
       const pdfOptions = {
         printBackground: true,


### PR DESCRIPTION
Sample output:

```
$ ./bin/asciidoctor-pdf examples/document/basic-example.adoc -a stylesheet=/path/to/custom.css
```
```
Failed to load resource: net::ERR_FILE_NOT_FOUND at file:///path/to/custom.css:1
> An uncaught exception happened within the HTML page: Error: ProgressEvent

TIP: You can add the --preview option to open the HTML page in a non-headless browser and debug it using the Developer Tools.
```
