### PR TITLE
adding language support for standard template

### DIFF
--- a/lib/document/templates.js
+++ b/lib/document/templates.js
@@ -145,6 +145,15 @@ const assetUriScheme = (node) => {
   return result
 }
 
+const langAttr = (node) => {
+  const attrNolang = node.getAttribute('nolang')
+  if (attrNolang === '') {
+    return ''
+  }
+  const attrLang = node.getAttribute('lang','en')
+  return ` lang="${attrLang}"`
+}
+
 const isSvgIconEnabled = (node) => node.getDocument().isAttribute('icontype', 'svg') || node.getDocument().isAttribute('icons', 'font')
 
 const titlePage = (node) => {
@@ -211,7 +220,7 @@ ${node.getContent()}
       bodyAttrs.push(`style="max-width: ${node.getAttribute('max-width')};"`)
     }
     return `<!DOCTYPE html>
-<html dir="ltr" lang="en">
+<html dir="ltr"${langAttr(node)}>
 <head>
 <title>${node.getDocumentTitle({ sanitize: true, use_fallback: true })}</title>
 <meta charset="UTF-8">

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -12,6 +12,34 @@ const templates = require('../lib/document/templates.js')
 converter.registerTemplateConverter(asciidoctor, templates)
 
 describe('Default converter', () => {
+  describe('Language', () => {
+    it('should have a default language', () => {
+      const doc = asciidoctor.load(`= Title
+
+== Section`)
+      const $ = cheerio.load(templates.document(doc))
+      expect($('html').attr('lang')).to.equal('en')
+    })
+
+    it('respect the document lang attribute', () => {
+      const doc = asciidoctor.load(`= Title
+:lang: de
+
+== Section`)
+      const $ = cheerio.load(templates.document(doc))
+      expect($('html').attr('lang')).to.equal('de')
+    })
+
+    it('respect the document nolang attribute', () => {
+      const doc = asciidoctor.load(`= Title
+:nolang:
+
+== Section`)
+      const $ = cheerio.load(templates.document(doc))
+      expect($('html').attr('lang')).to.be.undefined()
+    })
+  })
+
   describe('Page title', () => {
     it('should include a title page if title-page attribute is defined', () => {
       const doc = asciidoctor.load(`= Title


### PR DESCRIPTION
The current template has "en" as the only language. This PR uses the `lang` and `nolang` attribute to determine the HTML lang attribute like the html5.rb in Asciidoctor.

I placed the test cases quite at the top as the `<html>` is also at the top of the created file.