### PR TITLE
ensure rendering is complete before creating PDF

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -104,7 +104,9 @@ async function convert (processor, inputFile, options, timings, preview) {
       // capture console output
       page.on('console', msg => consoleLog(msg))
     }
-    await page.goto(`file://${tempFile}`, { waitUntil: 'networkidle2' })
+    await page.goto(`file://${tempFile}`, { waitUntil: 'networkidle0' })
+    const watchDog = page.waitForFunction('window.AsciidoctorPDF === undefined || window.AsciidoctorPDF.status === undefined || window.AsciidoctorPDF.status === "ready"')
+    await watchDog
     if (!preview) {
       const pdfOptions = {
         printBackground: true,

--- a/lib/document/templates.js
+++ b/lib/document/templates.js
@@ -239,6 +239,14 @@ ${syntaxHighlighterFooter(node, syntaxHighlighter, { cdn_base_url: cdnBaseUrl, l
 ${stemContent.content(node)}
 <script>
 ${pagedContent}
+window.AsciidoctorPDF = window.AsciidoctorPDF || {}
+window.AsciidoctorPDF.status = 'rendering'
+class PagedReadyHandler extends Paged.Handler {
+    afterRendered(pages) {
+        window.AsciidoctorPDF.status = 'ready'
+    }
+}
+Paged.registerHandlers(PagedReadyHandler);
 ${repeatTableHeadersContent}
 </script>
 </body>`


### PR DESCRIPTION
I had some touble with PDFs turning out with a white page on a complex document.
This PR makes extra sure that rendering is complete, assuming pages.js is the last thing that runs:

* networkidle2 -> networkidle0 to make sure that all networking is complete
* page.waitForFunction -> if window.status exists, wait for it to become "ready" (this would still allow themes that don't implement it)