### PR TITLE
resolves #124 upgrade MathJax to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -586,11 +586,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -1224,11 +1219,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
       "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "espree": {
       "version": "6.1.1",
@@ -2728,21 +2718,9 @@
       }
     },
     "mathjax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.0.0.tgz",
-      "integrity": "sha512-z4uLbDHNbs/aRuR6zCcnzwFQuMixkHCcWqgVaommfK/3cA1Ahq7OXemn+m8JwTYcBApSHgcrSbPr9sm3sZFL+A==",
-      "requires": {
-        "mathjax-full": "git://github.com/mathjax/MathJax-src.git"
-      }
-    },
-    "mathjax-full": {
-      "version": "git://github.com/mathjax/MathJax-src.git#1e1a30f0a89e52fa7764dbb510763145a4da49f1",
-      "from": "git://github.com/mathjax/MathJax-src.git",
-      "requires": {
-        "esm": "^3.2.25",
-        "mj-context-menu": "^0.2.0",
-        "speech-rule-engine": "^3.0.0-beta.6"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.0.1.tgz",
+      "integrity": "sha512-hrwOeKm3b1X4zpvLRSX89y3MZLRJTq0bSGIbo5M6BANOeGlL2z8Y8mZaKRFJ/WY4qcIrHp3f+Q9RWIaldOCUVg=="
     },
     "mdn-data": {
       "version": "1.1.4",
@@ -2827,11 +2805,6 @@
           }
         }
       }
-    },
-    "mj-context-menu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.2.0.tgz",
-      "integrity": "sha512-yJxrWBHCjFZEHsZgfs7m5g9OSCNzsVYadW6f6lX3pgZL67vmodtSW/4zhsYmuDKweXfHs0M1kJge1uQIasWA+g=="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -3973,16 +3946,6 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "speech-rule-engine": {
-      "version": "3.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.0.0-beta.6.tgz",
-      "integrity": "sha512-B7gcT53jAsKpx7WvFYQcyUlFmgS3Wa9KlDy0FY8SOTa+Wz5EqmI0MpCD5/fYm8/2qiCPp8HwZg+H3cBgM+sNVw==",
-      "requires": {
-        "commander": "*",
-        "wicked-good-xpath": "*",
-        "xmldom-sre": "^0.1.31"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4339,11 +4302,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
-    "wicked-good-xpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
-    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -4434,11 +4392,6 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
-    },
-    "xmldom-sre": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
-      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "file-url": "3.0.0",
     "fs-extra": "7.0.1",
     "html-entities": "^1.2.1",
-    "mathjax": "3.0.0",
+    "mathjax": "3.0.1",
     "pagedjs": "0.1.35",
     "pdf-lib": "^1.2.1",
     "puppeteer": "2.0.0",


### PR DESCRIPTION
`mathjax-full` is now a development dependency based on a version number (and not a git repository)

resolves #124