### PR TITLE
resolves #189 Use other delimiter for stylesheet override 

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,22 +203,22 @@ $ asciidoctor-pdf document.adoc -a title-page
 
 **Custom styles**
 
-You can provide a custom stylesheet using the `stylesheet` attribute. A custom stylesheet does completely replace the default stylesheets.
+You can provide a custom stylesheet using the `stylesheet` attribute. A custom stylesheet does completely replace the default stylesheet.
 
-    $ asciidoctor-pdf document.adoc -a stylesheet=custom.css
+    $ asciidoctor-pdf document.adoc -a stylesheet="custom.css"
 
 The `stylesheet` attribute can accept multiple comma delimited values (without spaces).
 This can be used to begin with a base stylesheet and then apply supplementary content.
 
-    $ asciidoctor-pdf document.adoc -a stylesheet=custom.css,override.css
+    $ asciidoctor-pdf document.adoc -a stylesheet="custom.css,override.css"
 
-It's also possible to use the default stylesheets and add custom styles with a custom stylesheet. All default stylesheets are available under the prefix `asciidoctor-pdf/css/`:
+It's also possible to use the default stylesheet and add custom styles with a custom stylesheet. All default stylesheets are available under the prefix `asciidoctor-pdf/css/`:
 
-    $ asciidoctor-pdf document.adoc -a stylesheet=asciidoctor-pdf/css/asciidoctor.css,asciidoctor-pdf/css/document.css,custom.css
+    $ asciidoctor-pdf document.adoc -a stylesheet="asciidoctor-pdf/css/asciidoctor.css,asciidoctor-pdf/css/document.css,custom.css"
 
 You can also specify where the stylesheets are located with the `stylesdir` attribute.
 
-    $ asciidoctor-pdf document.adoc -a stylesdir=css -a stylesheet=custom.css,override.css
+    $ asciidoctor-pdf document.adoc -a stylesdir=css -a stylesheet="custom.css,override.css"
 
 
 ## Custom layout

--- a/README.md
+++ b/README.md
@@ -201,16 +201,25 @@ The title page is enabled if either of these conditions are met:
 $ asciidoctor-pdf document.adoc -a title-page
 ```
 
-**Additional styles**
+**Custom styles**
 
-You can provide a custom stylesheet using the `stylesheet` attribute.
-You can also specify where the stylesheet is located with the `stylesdir` attribute.
+You can provide a custom stylesheet using the `stylesheet` attribute. A custom stylesheet does completely replace the default stylesheets.
 
     $ asciidoctor-pdf document.adoc -a stylesheet=custom.css
 
-The `stylesheet` attribute can accept multiple semi-colon delimited values (without spaces).
-For example `-a stylesheet=asciidoctor.css;override.css`.
-This could be used to begin with a base stylesheet and then apply supplementary content.
+The `stylesheet` attribute can accept multiple comma delimited values (without spaces).
+This can be used to begin with a base stylesheet and then apply supplementary content.
+
+    $ asciidoctor-pdf document.adoc -a stylesheet=custom.css,override.css
+
+It's also possible to use the default stylesheets and add custom styles with a custom stylesheet. All default stylesheets are available under the prefix `asciidoctor-pdf/css/`:
+
+    $ asciidoctor-pdf document.adoc -a stylesheet=asciidoctor-pdf/css/asciidoctor.css,asciidoctor-pdf/css/document.css,custom.css
+
+You can also specify where the stylesheets are located with the `stylesdir` attribute.
+
+    $ asciidoctor-pdf document.adoc -a stylesdir=css -a stylesheet=custom.css,override.css
+
 
 ## Custom layout
 

--- a/lib/document/document-converter.js
+++ b/lib/document/document-converter.js
@@ -267,7 +267,7 @@ ${node.getContent()}
     const stylesheetAttribute = node.getAttribute('stylesheet')
     if (stylesheetAttribute && stylesheetAttribute.trim() !== '') {
       return stylesheetAttribute
-        .split(';')
+        .split(',')
         .map(value => value.trim())
         .filter(value => value !== '')
         .map(stylesheet => {

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -317,7 +317,7 @@ describe('PDF converter', function () {
     opts.attributes = {}
     opts.attributes.reproducible = ''
     opts.to_file = outputFile
-    opts.attributes = { stylesheet: `${__dirname}/../css/asciidoctor.css;${__dirname}/../css/document.css;${__dirname}/../css/features/book.css;${__dirname}/fixtures/black-title-page.css` }
+    opts.attributes = { stylesheet: `${__dirname}/../css/asciidoctor.css,${__dirname}/../css/document.css,${__dirname}/../css/features/book.css,${__dirname}/fixtures/black-title-page.css` }
     await converter.convert(asciidoctor, { path: `${__dirname}/fixtures/title-page.adoc` }, opts, false)
     expect(outputFile).to.be.visuallyIdentical('title-page-background-color.pdf')
   })

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -102,7 +102,7 @@ Guillaume Grossetie
   })
 
   it('should load multiple stylesheets', () => {
-    const doc = asciidoctor.load('Hello world', { attributes: { stylesheet: `${__dirname}/fixtures/variable.css; ;${__dirname}/fixtures/theme.css;` } })
+    const doc = asciidoctor.load('Hello world', { attributes: { stylesheet: `${__dirname}/fixtures/variable.css, ,${__dirname}/fixtures/theme.css,` } })
     const $ = cheerio.load(doc.convert({ header_footer: true }))
     expect($('head').html()).to.not.have.string('Asciidoctor default stylesheet')
     expect($(`head > link[href="${__dirname}/fixtures/variable.css"]`).length).to.equal(1)


### PR DESCRIPTION
This resolves #189 by changing the stylesheet delimiter to be a comma `,`.
Be aware that this is a breaking change.