### PR TITLE
resolves #208 integrate with built-in template converter

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -15,6 +15,12 @@ function registerTemplateConverter (processor, templates) {
     constructor () {
       this.baseConverter = processor.Html5Converter.create()
       this.templates = templates
+      this.backendTraits = {
+        basebackend: 'html5',
+        outfilesuffix: '.pdf',
+        htmlsyntax: 'html',
+        supports_templates: true
+      }
     }
 
     convert (node, transform, opts) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@asciidoctor/core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.1.1.tgz",
-      "integrity": "sha512-yzV8GvrVUZst/lAlDvvEWY9Na9YhevE7PE3k1SvtQNyJEnpTWoKHrPG3soQ95nPM4oh2USMjpKDh4cEbvIRZpw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-WN/mFuU4SeWaDqpGvRwAf+Tq2T8NQkVVpZ3Ne1/ZRxDKElzFkqq8bGbmxSMWmMVzC+H9ZO1YxxbOjhWEiNvpOA==",
       "dev": true,
       "requires": {
         "asciidoctor-opal-runtime": "0.3.0",
@@ -157,6 +157,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+      "dev": true
     },
     "acorn": {
       "version": "7.1.1",
@@ -306,6 +312,12 @@
           }
         }
       }
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asciidoctor-opal-runtime": {
       "version": "0.3.0",
@@ -573,6 +585,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
       "dev": true
     },
     "concat-map": {
@@ -2156,6 +2174,18 @@
       "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "nunjucks": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.1.tgz",
+      "integrity": "sha512-LYlVuC1ZNSalQQkLNNPvcgPt2M9FTY9bs39mTCuFXtqh7jWbYzhDlmz2M6onPiXEhdZo+b9anRhc+uBGuJZ2bQ==",
+      "dev": true,
+      "requires": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "chokidar": "^3.3.0",
+        "commander": "^3.0.2"
       }
     },
     "object-assign": {

--- a/package.json
+++ b/package.json
@@ -48,16 +48,17 @@
     "yargs": "15.3.1"
   },
   "devDependencies": {
-    "@asciidoctor/core": "^2.1.0",
+    "@asciidoctor/core": "^2.2.0",
     "chai": "4.2.0",
     "cheerio": "^1.0.0-rc.3",
     "dirty-chai": "2.0.1",
     "mocha": "7.1.2",
+    "nunjucks": "^3.2.1",
     "pixelmatch": "^5.1.0",
     "rimraf": "^3.0.0",
     "standard": "14.3.3"
   },
   "peerDependencies": {
-    "@asciidoctor/core": "^2.1.0"
+    "@asciidoctor/core": "^2.2.0"
   }
 }

--- a/templates/paragraph.njk
+++ b/templates/paragraph.njk
@@ -1,0 +1,1 @@
+<p class="paragraph-nunjucks">{{ node.getContent() }}</p>

--- a/test/fixtures/templates/nunjucks/paragraph.njk
+++ b/test/fixtures/templates/nunjucks/paragraph.njk
@@ -1,0 +1,1 @@
+<p class="nunjucks">{{ node.getContent() | safe }}</p>

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -265,5 +265,10 @@ Just a preamble.`, { safe: 'safe' })
       const $ = cheerio.load(doc.convert())
       expect($('#toc > ul.sectlevel1 > li')).to.have.length(0)
     })
+
+    it('should use a template directory (Nunjucks)', () => {
+      const html = asciidoctor.convert('Hello *world*', { template_dirs: [`${__dirname}/fixtures/templates/nunjucks`] })
+      expect(html).to.equal('<p class="nunjucks">Hello <strong>world</strong></p>')
+    })
   })
 })


### PR DESCRIPTION
This pull request allow to do the following:

```
$ asciidoctor-pdf -T ./templates doc.adoc
```

It will use the templates files in the _templates_ directory and fallback to the default converter.


resolves #208